### PR TITLE
Stop beads from being erroneously removed after inference

### DIFF
--- a/pastis/algorithms.py
+++ b/pastis/algorithms.py
@@ -288,7 +288,7 @@ def run_pm2(directory):
               verbose=options["verbose"])
     X = pm2.fit(counts)
 
-    torm = np.array((counts.sum(axis=0) == 0)).flatten()
+    torm = np.array(((counts + counts.transpose()).sum(axis=0) == 0)).flatten()
 
     X[torm] = np.nan
 


### PR DESCRIPTION
torm is a filter that removes beads with 0 reads. The lower half of counts, as well as the diagonal, are 0. Therefore counts needs to be added to counts.transpose() for this sum to work as intended.