### PR TITLE
FIX install and tests

### DIFF
--- a/.github/workflows/build-html-and-deploy.yml
+++ b/.github/workflows/build-html-and-deploy.yml
@@ -21,6 +21,7 @@ jobs:
           auto-activate-base: false
           miniconda-version: 'latest'
           python-version: 3.9
+          channels: defaults
           environment-file: environment.yml
           activate-environment: pastis
 

--- a/.github/workflows/build-html-and-deploy.yml
+++ b/.github/workflows/build-html-and-deploy.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           auto-activate-base: false
           miniconda-version: 'latest'
-          python-version: ["3.9", "3.10", "3.11", "3.12"]
+          python-version: 3.9
           environment-file: environment.yml
           activate-environment: pastis
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           auto-activate-base: false
           miniconda-version: 'latest'
           python-version: ${{ matrix.python-version }}
+          channels: defaults
           environment-file: environment.yml
           activate-environment: pastis
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,19 +3,27 @@ on: [push, pull_request]
 
 jobs:
   tests:
+    name: linux-cp${{ matrix.python-version }}-${{ matrix.OPTIONS_NAME }}
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2
         with:
           persist-credentials: false
+
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           auto-activate-base: false
           miniconda-version: 'latest'
-          python-version: ["3.9", "3.10", "3.11", "3.12"]
+          python-version: ${{ matrix.python-version }}
           environment-file: environment.yml
           activate-environment: pastis
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout 🛎️

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           auto-activate-base: false

--- a/Makefile
+++ b/Makefile
@@ -19,22 +19,19 @@ clean:
 	rm -rf example/*MDS*
 	rm -rf examples/filtering_example/*.png
 
-in: inplace # just a shortcut
-
-test: in
+test:
 	$(PYTEST) --showlocals -v pastis --durations=20
 
 test-coverage:
 	rm -rf coverage .coverage
 	$(PYTEST) pastis --showlocals -v --cov=pastis
 
-doc: inplace
+doc:
 	$(MAKE) -C doc html
 
-doc-noplot: inplace
+doc-noplot:
 	$(MAKE) -C doc html-noplot
 
 code-analysis:
 	flake8 pastis | grep -v __init__
 	pylint -E -i y pastis/ -d E1103,E0611,E1101
-

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
     - default
 dependencies:
     - python
-    - setuptools>=50.0, <60.0
+    - setuptools>=77
     - numpy
     - pip
     - pip:
@@ -11,7 +11,7 @@ dependencies:
         - scipy
         - scikit-learn
         - matplotlib
-        - iced
+        - git+https://github.com/gesinecauer/iced.git@fix_install_from_repo
         - joblib
         - pandas
         - sphinx-gallery

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
         - scipy
         - scikit-learn
         - matplotlib
-        - git+https://github.com/gesinecauer/iced.git@fix_install_from_repo
+        - iced
         - joblib
         - pandas
         - sphinx-gallery

--- a/pastis/config.py
+++ b/pastis/config.py
@@ -96,7 +96,7 @@ def parse(filename=None):
         raise IOError("File %s doesn't existe" % filename)
 
     config = ConfigParser.ConfigParser()
-    config.readfp(open(filename))
+    config.read_file(open(filename))
     for key in options.keys():
         try:
             if type(options[key]) == bool:

--- a/pastis/optimization/tests/test_negative_binomial.py
+++ b/pastis/optimization/tests/test_negative_binomial.py
@@ -1,7 +1,6 @@
 import numpy as np
 from scipy import sparse
-from nose.tools import assert_almost_equal
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_almost_equal
 from sklearn.metrics import euclidean_distances
 from pastis.optimization import negative_binomial
 from scipy.optimize import check_grad

--- a/pastis/optimization/tests/test_negative_binomial_structure.py
+++ b/pastis/optimization/tests/test_negative_binomial_structure.py
@@ -1,8 +1,7 @@
 import numpy as np
 from scipy import sparse
 from sklearn.metrics import euclidean_distances
-from numpy.testing import assert_array_almost_equal
-from nose.tools import assert_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_almost_equal
 from scipy.optimize import check_grad
 
 from pastis import dispersion
@@ -29,7 +28,7 @@ def test_negative_binomial_obj_dense():
     obj_ = negative_binomial_structure.negative_binomial_obj(
         random_state.rand(*X.shape),
         counts, alpha=alpha, beta=beta)
-    assert(obj < obj_)
+    assert obj < obj_
 
     obj = negative_binomial_structure.negative_binomial_obj(
         X, counts, alpha=alpha, beta=beta, use_zero_counts=True)
@@ -37,7 +36,7 @@ def test_negative_binomial_obj_dense():
     obj_ = negative_binomial_structure.negative_binomial_obj(
         random_state.rand(*X.shape),
         counts, alpha=alpha, beta=beta, use_zero_counts=True)
-    assert(obj < obj_)
+    assert obj < obj_
 
 
 def test_negative_binomial_obj_sparse():
@@ -67,7 +66,7 @@ def test_negative_binomial_obj_sparse():
         counts.toarray(), alpha=alpha, beta=beta)
 
     # The objective for a random point should be larger than for the solution
-    assert(obj < obj_sparse)
+    assert obj < obj_sparse
     # The objective in sparse and dense should be equal
     assert_almost_equal(obj_sparse, obj_dense)
 
@@ -100,7 +99,7 @@ def test_negative_binomial_obj_sparse_dispersion_biased():
     obj_ = negative_binomial_structure.negative_binomial_obj(
         random_state.rand(*X.shape),
         counts, dispersion=d, alpha=alpha, beta=beta)
-    assert(obj_sparse < obj_)
+    assert obj_sparse < obj_
     assert_almost_equal(obj_sparse, obj_dense, 6)
 
 
@@ -178,7 +177,7 @@ def test_negative_binomial_gradient_sparse_dispersed():
 
     assert_array_almost_equal(gradient_dense, gradient_sparse)
     assert_array_almost_equal(
-       np.zeros(gradient_sparse.shape), gradient_sparse, -5)
+        np.zeros(gradient_sparse.shape), gradient_sparse, -5)
 
 
 def test_estimate_X():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pastis"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 version = "0.5.0"
 dependencies = [
   "numpy>=1.16.0",


### PR DESCRIPTION
Bug fixes:
- _Temporarily_ install ICED from [my branch](https://github.com/gesinecauer/iced/tree/fix_install_from_repo) during Github workflows, since installation from main repo is broken and the [version of ICED on PyPI (0.5.13)](https://pypi.org/project/iced/) requires python <= 3.8
- Fix specification of multiple Python versions in Github workflows
- Remove remnants of old code from 'Makefile'
- Replace functions that no longer exist in recent versions of python/etc (in 'pastis/config.py' & 'pastis/optimization/tests')

Other changes:
- Require setuptools>=77 (allows use of updated syntax for specifying license, per [PEP 639](https://peps.python.org/pep-0639/))
- Require python>=3.9 (allows use of setuptools>=77)
- Update versions of `actions/checkout` and `conda-incubator/setup-miniconda`
- Explicitly add `channels: defaults` to Github workflows (resolve warning about how implicitly adding 'defaults' is deprecated)